### PR TITLE
chore: Allow release please to be re-run manually

### DIFF
--- a/.github/workflows/release-check.yaml
+++ b/.github/workflows/release-check.yaml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This is useful if we apply release note corrections as documented here: https://github.com/googleapis/release-please#how-can-i-fix-release-notes