### PR TITLE
feat: update code to support bindings version 1.4<

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.6.0](https://github.com/agntcy/slim-a2a-python/compare/v0.5.0...v0.6.0) (2026-06-10)
+
+
+### ⚠ BREAKING CHANGES
+
+* require slim-bindings >=1.4,<2
+
+### Features
+
+* support slim-bindings 1.4.x. The SLIMRPC code generator now emits server handler classes that subclass the strict slim-bindings RPC handler traits (`UnaryUnaryHandler`, `UnaryStreamHandler`, `StreamUnaryHandler`, `StreamStreamHandler`), fixing `TypeError: Expected UnaryUnaryHandler subclass` raised by `add_*Servicer_to_server()` against slim-bindings 1.4.x. The dependency constraint is bumped from `slim-bindings~=1.1` to `slim-bindings>=1.4,<2`.
+
 ## [0.5.0](https://github.com/agntcy/slim-a2a-python/compare/v0.4.0...v0.5.0) (2026-05-06)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,13 @@
 
 [project]
 name = "slima2a"
-version = "0.5.0"
+version = "0.6.0"
 description = "A2A protocol over slimrpc"
 readme = "README.md"
 requires-python = ">=3.10, <4.0"
 dependencies = [
     "a2a-sdk[telemetry,sqlite]==1.0.0-alpha.0",
-    "slim-bindings~=1.1",
+    "slim-bindings>=1.4,<2",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/slima2a/types/v0/a2a_pb2_slimrpc.py
+++ b/slima2a/types/v0/a2a_pb2_slimrpc.py
@@ -433,7 +433,7 @@ class A2AServiceServicer:
 
 
 
-class _A2AServiceServicer_SendMessage_Handler:
+class _A2AServiceServicer_SendMessage_Handler(slim_bindings.UnaryUnaryHandler):
     def __init__(self, servicer):
         self.servicer = servicer
 
@@ -451,7 +451,7 @@ class _A2AServiceServicer_SendMessage_Handler:
                 details=None
             )
 
-class _A2AServiceServicer_SendStreamingMessage_Handler:
+class _A2AServiceServicer_SendStreamingMessage_Handler(slim_bindings.UnaryStreamHandler):
     def __init__(self, servicer):
         self.servicer = servicer
 
@@ -472,7 +472,7 @@ class _A2AServiceServicer_SendStreamingMessage_Handler:
             )
             await sink.send_error_async(rpc_error)
 
-class _A2AServiceServicer_GetTask_Handler:
+class _A2AServiceServicer_GetTask_Handler(slim_bindings.UnaryUnaryHandler):
     def __init__(self, servicer):
         self.servicer = servicer
 
@@ -490,7 +490,7 @@ class _A2AServiceServicer_GetTask_Handler:
                 details=None
             )
 
-class _A2AServiceServicer_CancelTask_Handler:
+class _A2AServiceServicer_CancelTask_Handler(slim_bindings.UnaryUnaryHandler):
     def __init__(self, servicer):
         self.servicer = servicer
 
@@ -508,7 +508,7 @@ class _A2AServiceServicer_CancelTask_Handler:
                 details=None
             )
 
-class _A2AServiceServicer_TaskSubscription_Handler:
+class _A2AServiceServicer_TaskSubscription_Handler(slim_bindings.UnaryStreamHandler):
     def __init__(self, servicer):
         self.servicer = servicer
 
@@ -529,7 +529,7 @@ class _A2AServiceServicer_TaskSubscription_Handler:
             )
             await sink.send_error_async(rpc_error)
 
-class _A2AServiceServicer_CreateTaskPushNotificationConfig_Handler:
+class _A2AServiceServicer_CreateTaskPushNotificationConfig_Handler(slim_bindings.UnaryUnaryHandler):
     def __init__(self, servicer):
         self.servicer = servicer
 
@@ -547,7 +547,7 @@ class _A2AServiceServicer_CreateTaskPushNotificationConfig_Handler:
                 details=None
             )
 
-class _A2AServiceServicer_GetTaskPushNotificationConfig_Handler:
+class _A2AServiceServicer_GetTaskPushNotificationConfig_Handler(slim_bindings.UnaryUnaryHandler):
     def __init__(self, servicer):
         self.servicer = servicer
 
@@ -565,7 +565,7 @@ class _A2AServiceServicer_GetTaskPushNotificationConfig_Handler:
                 details=None
             )
 
-class _A2AServiceServicer_ListTaskPushNotificationConfig_Handler:
+class _A2AServiceServicer_ListTaskPushNotificationConfig_Handler(slim_bindings.UnaryUnaryHandler):
     def __init__(self, servicer):
         self.servicer = servicer
 
@@ -583,7 +583,7 @@ class _A2AServiceServicer_ListTaskPushNotificationConfig_Handler:
                 details=None
             )
 
-class _A2AServiceServicer_GetAgentCard_Handler:
+class _A2AServiceServicer_GetAgentCard_Handler(slim_bindings.UnaryUnaryHandler):
     def __init__(self, servicer):
         self.servicer = servicer
 
@@ -601,7 +601,7 @@ class _A2AServiceServicer_GetAgentCard_Handler:
                 details=None
             )
 
-class _A2AServiceServicer_DeleteTaskPushNotificationConfig_Handler:
+class _A2AServiceServicer_DeleteTaskPushNotificationConfig_Handler(slim_bindings.UnaryUnaryHandler):
     def __init__(self, servicer):
         self.servicer = servicer
 

--- a/slima2a/types/v1/a2a_pb2_slimrpc.py
+++ b/slima2a/types/v1/a2a_pb2_slimrpc.py
@@ -470,7 +470,7 @@ class A2AServiceServicer:
 
 
 
-class _A2AServiceServicer_SendMessage_Handler:
+class _A2AServiceServicer_SendMessage_Handler(slim_bindings.UnaryUnaryHandler):
     def __init__(self, servicer):
         self.servicer = servicer
 
@@ -488,7 +488,7 @@ class _A2AServiceServicer_SendMessage_Handler:
                 details=None
             )
 
-class _A2AServiceServicer_SendStreamingMessage_Handler:
+class _A2AServiceServicer_SendStreamingMessage_Handler(slim_bindings.UnaryStreamHandler):
     def __init__(self, servicer):
         self.servicer = servicer
 
@@ -509,7 +509,7 @@ class _A2AServiceServicer_SendStreamingMessage_Handler:
             )
             await sink.send_error_async(rpc_error)
 
-class _A2AServiceServicer_GetTask_Handler:
+class _A2AServiceServicer_GetTask_Handler(slim_bindings.UnaryUnaryHandler):
     def __init__(self, servicer):
         self.servicer = servicer
 
@@ -527,7 +527,7 @@ class _A2AServiceServicer_GetTask_Handler:
                 details=None
             )
 
-class _A2AServiceServicer_ListTasks_Handler:
+class _A2AServiceServicer_ListTasks_Handler(slim_bindings.UnaryUnaryHandler):
     def __init__(self, servicer):
         self.servicer = servicer
 
@@ -545,7 +545,7 @@ class _A2AServiceServicer_ListTasks_Handler:
                 details=None
             )
 
-class _A2AServiceServicer_CancelTask_Handler:
+class _A2AServiceServicer_CancelTask_Handler(slim_bindings.UnaryUnaryHandler):
     def __init__(self, servicer):
         self.servicer = servicer
 
@@ -563,7 +563,7 @@ class _A2AServiceServicer_CancelTask_Handler:
                 details=None
             )
 
-class _A2AServiceServicer_SubscribeToTask_Handler:
+class _A2AServiceServicer_SubscribeToTask_Handler(slim_bindings.UnaryStreamHandler):
     def __init__(self, servicer):
         self.servicer = servicer
 
@@ -584,7 +584,7 @@ class _A2AServiceServicer_SubscribeToTask_Handler:
             )
             await sink.send_error_async(rpc_error)
 
-class _A2AServiceServicer_CreateTaskPushNotificationConfig_Handler:
+class _A2AServiceServicer_CreateTaskPushNotificationConfig_Handler(slim_bindings.UnaryUnaryHandler):
     def __init__(self, servicer):
         self.servicer = servicer
 
@@ -602,7 +602,7 @@ class _A2AServiceServicer_CreateTaskPushNotificationConfig_Handler:
                 details=None
             )
 
-class _A2AServiceServicer_GetTaskPushNotificationConfig_Handler:
+class _A2AServiceServicer_GetTaskPushNotificationConfig_Handler(slim_bindings.UnaryUnaryHandler):
     def __init__(self, servicer):
         self.servicer = servicer
 
@@ -620,7 +620,7 @@ class _A2AServiceServicer_GetTaskPushNotificationConfig_Handler:
                 details=None
             )
 
-class _A2AServiceServicer_ListTaskPushNotificationConfigs_Handler:
+class _A2AServiceServicer_ListTaskPushNotificationConfigs_Handler(slim_bindings.UnaryUnaryHandler):
     def __init__(self, servicer):
         self.servicer = servicer
 
@@ -638,7 +638,7 @@ class _A2AServiceServicer_ListTaskPushNotificationConfigs_Handler:
                 details=None
             )
 
-class _A2AServiceServicer_GetExtendedAgentCard_Handler:
+class _A2AServiceServicer_GetExtendedAgentCard_Handler(slim_bindings.UnaryUnaryHandler):
     def __init__(self, servicer):
         self.servicer = servicer
 
@@ -656,7 +656,7 @@ class _A2AServiceServicer_GetExtendedAgentCard_Handler:
                 details=None
             )
 
-class _A2AServiceServicer_DeleteTaskPushNotificationConfig_Handler:
+class _A2AServiceServicer_DeleteTaskPushNotificationConfig_Handler(slim_bindings.UnaryUnaryHandler):
     def __init__(self, servicer):
         self.servicer = servicer
 

--- a/uv.lock
+++ b/uv.lock
@@ -1519,22 +1519,22 @@ wheels = [
 
 [[package]]
 name = "slim-bindings"
-version = "1.3.0"
+version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/7e/c1dc0f493274e8986abf248830d1f9307bfe351a705d231c3ec960c9b3bc/slim_bindings-1.3.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:255fe49242a09014a7e25912a7ca07b88f5bc61dd1cf989b3ce7322be647f190", size = 14656295, upload-time = "2026-03-31T15:26:48.49Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/62/014b8e15a8da96030f478432f5d8c2101e2025346def29951d3e20bf59b7/slim_bindings-1.3.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f020d0eea1aba44b3f57b0187a8a82882f16058f71c78e4df7428bc1c5b7d512", size = 14366290, upload-time = "2026-03-31T15:26:50.592Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/f6/fe1048972e33bb919ec2cb3c9301398eb6afb3d65af6cc1277344675a9de/slim_bindings-1.3.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:65b6668c78956360fc4c70380908f2a2cee1d7f6914720882f74d40ebcd9ceff", size = 13007812, upload-time = "2026-03-31T15:26:52.875Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/d4/c46f98481de243893b1c8d7043ac20fc8c9d16c14a5d49f78780dcc4d8e4/slim_bindings-1.3.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:0ecadbc39684bef1bcee4b054002758a559a8167b7a3a24e77c9890ca31a4a7d", size = 13473600, upload-time = "2026-03-31T15:26:54.787Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/89/3f0d453d2b7e1fc6afef7bb3d4936f7d5b506db5cc90957667ea685e7b9d/slim_bindings-1.3.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b5b47586eb6e9508e9d6f74565840490d3db829c9bd1c7ba257df63acc68fee2", size = 12916139, upload-time = "2026-03-31T15:26:56.905Z" },
-    { url = "https://files.pythonhosted.org/packages/08/82/7b286fd053a5d2ecaacc38f1cffb9455d48fd7bd7d2ee773661706047d13/slim_bindings-1.3.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a91820bcb36631eacc3c74de2a0c59e36060dece8a6ad7cfcea820d89023075a", size = 13370880, upload-time = "2026-03-31T15:26:59.04Z" },
-    { url = "https://files.pythonhosted.org/packages/51/17/32f5673d7d9f8995a116cf184061dbf44e4c532bc91c9311d7a723b92073/slim_bindings-1.3.0-py3-none-win_amd64.whl", hash = "sha256:4d7f8397161ebc9d1257d1160b6fb6701c2834e27b6619b291c02972cb9b7d2c", size = 12063227, upload-time = "2026-03-31T15:27:01.351Z" },
-    { url = "https://files.pythonhosted.org/packages/33/14/d02908623ddc41609a543dd8698b9fcb86cc272d98a58b98cfb83178cba7/slim_bindings-1.3.0-py3-none-win_arm64.whl", hash = "sha256:2224ba6fbd28b6c5c670624466e25ea392cc29a1b35275d96415e3c14e82d8a0", size = 11554094, upload-time = "2026-03-31T15:27:03.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/10/f781f076ced49a5dbd4a5eb04b1948fcd82fcd0948c2b80ecbe5c94f8ec8/slim_bindings-1.4.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:44e985aae7203d4b9173b0a824a26a8bea39a02e203ad89e0e1abec7d3b86ef5", size = 12398410, upload-time = "2026-05-23T08:57:12.545Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/11/a30899045e56b12b595683e4de194210246f6e6b95185ff520cf3d99d2be/slim_bindings-1.4.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5667a87549c4d1bf6decef34acbd8b2920b8d35451200dcf2cd55f2fb7cbc929", size = 12105663, upload-time = "2026-05-23T08:57:16.134Z" },
+    { url = "https://files.pythonhosted.org/packages/04/80/398d41159ddfa4dabd9102b23888e3bfc85a9a439403aa95814ba6de7cab/slim_bindings-1.4.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:2327211828e59a0c7dc970b1210abdd4f32cc1dd3c41a68ab1e5d52f16e34664", size = 12600843, upload-time = "2026-05-23T08:57:19.022Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d3/34630486515e6236d1887aa8f49a845b1bb6b844e0773d00d5e9daa9c540/slim_bindings-1.4.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:42036cb27c7165beb7a68010aceec6a514f0de0bef164711585281d5ad0f57d1", size = 13041099, upload-time = "2026-05-23T08:57:21.717Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/ec/1ad484dcfb0f9edd87015832a4dc3eb2638a71fb3a38646b9611cee4fc35/slim_bindings-1.4.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d96b59c0108a588c55e5335a9feee74bc9b78e468a5cd4dd038e78020ce85b17", size = 12598901, upload-time = "2026-05-23T08:57:24.096Z" },
+    { url = "https://files.pythonhosted.org/packages/80/54/3c615508b65fe34d67368d67e8321becec6bc566888e261ae45fb98afa74/slim_bindings-1.4.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:618137b056627326fa55f5eeae99e800b476f1951460d5ccf58a7a0b38ef16df", size = 13031199, upload-time = "2026-05-23T08:57:26.305Z" },
+    { url = "https://files.pythonhosted.org/packages/77/41/87d47c1fd47a1681b6377419e941ba22e416490a08577242b4da1d5a89ed/slim_bindings-1.4.1-py3-none-win_amd64.whl", hash = "sha256:9c89dbdbee2ffcb92b4ffe72593556b5cc14b24226a7f617838897e44bd1f897", size = 11650639, upload-time = "2026-05-23T08:57:28.92Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/38/f6425ceb8ecbae63c17bd08af5321d399b51b459b967d7625be6375c56f8/slim_bindings-1.4.1-py3-none-win_arm64.whl", hash = "sha256:dee180e534d4b10c912190aa143dea03f2cb996f5ed58036c5257f6f028feaab", size = 10929753, upload-time = "2026-05-23T08:57:31.067Z" },
 ]
 
 [[package]]
 name = "slima2a"
-version = "0.4.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["sqlite", "telemetry"] },
@@ -1560,7 +1560,7 @@ testing = [
 [package.metadata]
 requires-dist = [
     { name = "a2a-sdk", extras = ["telemetry", "sqlite"], specifier = "==1.0.0a0" },
-    { name = "slim-bindings", specifier = "~=1.1" },
+    { name = "slim-bindings", specifier = ">=1.4,<2" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Make slima2a's generated SLIMRPC server code compatible with slim-bindings 1.4.x and bump the dependency constraint accordingly.

